### PR TITLE
Make `lokid-rpc-ip` and `lokid-rpc-port` options still work

### DIFF
--- a/httpserver/command_line.cpp
+++ b/httpserver/command_line.cpp
@@ -37,6 +37,8 @@ void command_line_parser::parse_args(int argc, char* argv[]) {
         ("ip", po::value<std::string>(), "(unused)")
         ("port", po::value(&options_.port), "Port to listen on")
         ("oxend-key", po::value(&options_.oxend_key), "Legacy secret key (test only)")
+        ("lokid-rpc-ip", po::value(&options_.oxend_rpc_ip), "Backwards compatible option for oxend RPC IP")
+        ("lokid-rpc-port", po::value(&options_.oxend_rpc_port), "Backwards compatible option for oxend RPC port")
         ("oxend-x25519-key", po::value(&options_.oxend_x25519_key), "x25519 secret key (test only)")
         ("oxend-ed25519-key", po::value(&options_.oxend_ed25519_key), "ed25519 public key (test only)");
     // clang-format on

--- a/httpserver/command_line.cpp
+++ b/httpserver/command_line.cpp
@@ -21,7 +21,7 @@ void command_line_parser::parse_args(int argc, char* argv[]) {
         ("data-dir", po::value(&options_.data_dir), "Path to persistent data (defaults to ~/.oxen/storage)")
         ("config-file", po::value(&config_file), "Path to custom config file (defaults to `storage-server.conf' inside --data-dir)")
         ("log-level", po::value(&options_.log_level), "Log verbosity level, see Log Levels below for accepted values")
-        ("oxend-rpc-ip", po::value(&options_.oxend_rpc_port), "RPC IP on which the local Oxen daemon is listening (usually localhost)")
+        ("oxend-rpc-ip", po::value(&options_.oxend_rpc_ip), "RPC IP on which the local Oxen daemon is listening (usually localhost)")
         ("oxend-rpc-port", po::value(&options_.oxend_rpc_port), "RPC port on which the local Oxen daemon is listening")
         ("lmq-port", po::value(&options_.lmq_port), "Port used by LokiMQ")
         ("testnet", po::bool_switch(&options_.testnet), "Start storage server in testnet mode")


### PR DESCRIPTION
Adds lokid-rpc-ip and lokid-rpc-port as hidden options so that they still work if specified on command line or in the config file.